### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,6 @@
 name: iOS starter workflow
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nicolasFernandez/DnDWorld/security/code-scanning/9](https://github.com/nicolasFernandez/DnDWorld/security/code-scanning/9)

To fix this issue, add a `permissions` key with the value `contents: read` at the root of the workflow file (`.github/workflows/ios.yml`). This will set read-only access on the repository contents for all jobs and steps, unless overridden at the job level. Add the block right after the `name:` and before the `on:` block (lines 1-2), as per typical YAML formatting for GitHub Actions workflow files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
